### PR TITLE
VSmartCardTCP: remove unneccessary 3s delay

### DIFF
--- a/src/main/java/com/licel/jcardsim/remote/VSmartCardTCPProtocol.java
+++ b/src/main/java/com/licel/jcardsim/remote/VSmartCardTCPProtocol.java
@@ -47,11 +47,6 @@ public class VSmartCardTCPProtocol {
 
     public void connect(String host, int port) throws IOException {
         socket = new Socket(host, port);
-
-        try {
-            TimeUnit.SECONDS.sleep(3);
-        } catch (InterruptedException ignore) {}
-
         dataInput   = socket.getInputStream();
         dataOutput  = socket.getOutputStream();
     }


### PR DESCRIPTION
This 3-second delay is not neccessary, things work better without it.