### PR TITLE
Fix parameters of RandomData.setSeed()

### DIFF
--- a/simulator/src/main/java/com/licel/jcardsim/crypto/RandomDataImpl.java
+++ b/simulator/src/main/java/com/licel/jcardsim/crypto/RandomDataImpl.java
@@ -58,7 +58,7 @@ public class RandomDataImpl extends RandomData {
 
     public void setSeed(byte[] buffer, short offset, short length) {
         // XXX: for ALG_PRESEEDED_DRBG seeding should set known state ?
-        engine.addSeedMaterial(Arrays.copyOfRange(buffer, offset, length));
+        engine.addSeedMaterial(Arrays.copyOfRange(buffer, offset, offset + length));
     }
 
     public byte getAlgorithm() {


### PR DESCRIPTION
Random.Data.setSeed() uses offset/length-parameters:
```setSeed(byte[] buffer, short offset, short length)```

Where java.util.Arrays.copyOfRange() uses a from/to-notation:
```copyOfRange(byte[] original, int from, int to)```

Besides the different semantics, this difference can lead to an `IllegalArgumentException` if `offset` is larger than the `length` of the seed.

This small patch fixes the handling.