### PR TITLE
fix: `buildKey(byte, byte, short, bool)` for ALG_TYPE_AES and ALG_TYPE_DES

### DIFF
--- a/simulator/src/main/java/pro/javacard/engine/proxy/javacard/security/KeyBuilderProxy.java
+++ b/simulator/src/main/java/pro/javacard/engine/proxy/javacard/security/KeyBuilderProxy.java
@@ -155,6 +155,30 @@ public class KeyBuilderProxy {
         }
         Key key = null;
         switch (algorithmicKeyType) {
+            case KeyBuilder.ALG_TYPE_DES:
+                if (keyLength != 64 && keyLength != 128 && keyLength != 192) {
+                    CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+                }
+                if (keyMemoryType == JCSystem.MEMORY_TYPE_TRANSIENT_DESELECT) {
+                    key = new SymmetricKeyImpl(KeyBuilder.TYPE_DES_TRANSIENT_DESELECT, keyLength);
+                } else if (keyMemoryType == JCSystem.MEMORY_TYPE_TRANSIENT_RESET) {
+                    key = new SymmetricKeyImpl(KeyBuilder.TYPE_DES_TRANSIENT_RESET, keyLength);
+                } else {
+                    key = new SymmetricKeyImpl(KeyBuilder.TYPE_DES, keyLength);
+                }
+                break;
+            case KeyBuilder.ALG_TYPE_AES:
+                if (keyLength != 128 && keyLength != 192 && keyLength != 256) {
+                    CryptoException.throwIt(CryptoException.ILLEGAL_VALUE);
+                }
+                if (keyMemoryType == JCSystem.MEMORY_TYPE_TRANSIENT_DESELECT) {
+                    key = new SymmetricKeyImpl(KeyBuilder.TYPE_AES_TRANSIENT_DESELECT, keyLength);
+                } else if (keyMemoryType == JCSystem.MEMORY_TYPE_TRANSIENT_RESET) {
+                    key = new SymmetricKeyImpl(KeyBuilder.TYPE_AES_TRANSIENT_RESET, keyLength);
+                } else {
+                    key = new SymmetricKeyImpl(KeyBuilder.TYPE_AES, keyLength);
+                }
+                break;
             case KeyBuilder.ALG_TYPE_EC_FP_PARAMETERS:
                 key = new ECPublicKeyImpl(KeyBuilder.TYPE_EC_FP_PUBLIC, keyLength, keyMemoryType);
                 break;

--- a/simulator/src/test/java/com/licel/jcardsim/crypto/AuthenticatedSymmetricCipherImplTest.java
+++ b/simulator/src/test/java/com/licel/jcardsim/crypto/AuthenticatedSymmetricCipherImplTest.java
@@ -16,6 +16,8 @@
 package com.licel.jcardsim.crypto;
 
 import com.licel.jcardsim.SimulatorCoreTest;
+
+import javacard.framework.JCSystem;
 import javacard.security.AESKey;
 import javacard.security.CryptoException;
 import javacard.security.DESKey;
@@ -406,8 +408,33 @@ public class AuthenticatedSymmetricCipherImplTest extends SimulatorCoreTest  {
         assertEquals(true, engine.verifyTag(tag, (short) 0, (short) tag.length, TAG_SIZE));
     }
 
+
     @Test
-    public void testAES_GCM_OnlineEncryptAndDecryptWithIV() {
+    public void testAES_GCM_OnlineEncryptAndDecryptWithIV_MemoryTypes() {
+        AESKey aesKey;
+        // test KeyBuilder.TYPE_AES_*
+        aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_256, false);
+        testAES_GCM_OnlineEncryptAndDecryptWithIV(aesKey);
+
+        aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES_TRANSIENT_DESELECT, KeyBuilder.LENGTH_AES_256, false);
+        testAES_GCM_OnlineEncryptAndDecryptWithIV(aesKey);
+
+        aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES_TRANSIENT_RESET, KeyBuilder.LENGTH_AES_256, false);
+        testAES_GCM_OnlineEncryptAndDecryptWithIV(aesKey);
+
+
+        // test AES with JCSystem.MEMORY_TYPE_*
+        aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.ALG_TYPE_AES, JCSystem.MEMORY_TYPE_TRANSIENT_DESELECT, KeyBuilder.LENGTH_AES_256, false);
+        testAES_GCM_OnlineEncryptAndDecryptWithIV(aesKey);
+
+        aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.ALG_TYPE_AES, JCSystem.MEMORY_TYPE_TRANSIENT_RESET, KeyBuilder.LENGTH_AES_256, false);
+        testAES_GCM_OnlineEncryptAndDecryptWithIV(aesKey);
+
+        aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.ALG_TYPE_AES, JCSystem.MEMORY_TYPE_PERSISTENT, KeyBuilder.LENGTH_AES_256, false);
+        testAES_GCM_OnlineEncryptAndDecryptWithIV(aesKey);
+    }
+
+    public void testAES_GCM_OnlineEncryptAndDecryptWithIV(AESKey aesKey) {
         byte[] key256Bit = new byte[256 / Byte.SIZE];
         new Random().nextBytes(key256Bit);
 
@@ -417,7 +444,6 @@ public class AuthenticatedSymmetricCipherImplTest extends SimulatorCoreTest  {
         byte[] iv96Bit = new byte[96 / Byte.SIZE];
         new Random().nextBytes(iv96Bit);
 
-        AESKey aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_256, false);
         aesKey.setKey(key256Bit, (short) 0);
 
         AEADCipher engine = (AEADCipher) Cipher.getInstance(AEADCipher.ALG_AES_GCM, false);


### PR DESCRIPTION
Fixes #17 

Previously it threw `CryptoException` from example call:
```java
KeyBuilder.buildKey(
    KeyBuilder.ALG_TYPE_AES,
    JCSystem.MEMORY_TYPE_TRANSIENT_DESELECT,
    KeyBuilder.LENGTH_AES_256,
    false
);
```