### PR TITLE
Fix FaultTest line numbers after SPDX header shift

### DIFF
--- a/simulator/src/test/java/com/licel/jcardsim/base/FaultTest.java
+++ b/simulator/src/test/java/com/licel/jcardsim/base/FaultTest.java
@@ -17,9 +17,7 @@ public class FaultTest {
     public void testFault() {
         // Flip condition on step 2 (SELECT is step 1, the test command is step 2)
         var config = FaultyConfig.builder()
-                .faultyAt(2, FaultApplet.class, 62)
-                .faultyAt(2, FaultApplet.class, 24)
-
+                .faultyAt(2, FaultApplet.class, 64)
                 .build();
         var instance = new Simulator(config);
         var aid = AIDUtil.create("010203040506");


### PR DESCRIPTION
## Summary
Commit 7113bb4 (`Switch license headers to SPDX/REUSE`) added 2 SPDX lines to the top of every file, including `FaultApplet.java`, but didn't bump the line refs in `FaultTest`. The IFEQ for `if (branch != 0)` moved from line 62 to 64, so the flip no longer fires and `testFault` returned `0x6f00` instead of `0x9000`.

The second ref (line 24) pointed at `foo = (byte[]) tmp;` — no conditional jump for the interceptor to flip, so it was a no-op even before the shift. Removed.

## Test plan
- [x] `./mvnw -pl simulator test -Dtest=FaultTest` — `testFault` and `testNoFault` both pass
- [x] `./mvnw clean install` — 218 tests, 0 failures, 0 errors